### PR TITLE
Misc improvements to CD pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,11 @@ jobs:
         - "10"
       install:
         - git submodule update --init --recursive
-        - cd app && yarn install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
+        - cd app
+        - yarn install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
       script:
-        - cd app && yarn lint
-        - cd app && yarn test
+        - yarn lint
+        - yarn test
     # - stage: ios-beta
     #   if: branch = master AND type = push
     #   os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ aliases:
 
   - &android-cache
     yarn: true
+    bundler: true
     directories:
       - ~/.cache/yarn
       - ~/.gradle/caches
@@ -53,7 +54,7 @@ jobs:
       cache: *android-cache
       before_install:
         - rvm install 2.6.5
-        - gem install fastlane
+        - bundle install --deployment
         - nvm install 10.17.0
         - npm install -g yarn
         - yes | sdkmanager "platforms;android-28"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,13 @@ aliases:
       - "google-gdk-license-.+"
 
   - &android-cache
+    yarn: true
     directories:
       - ~/.cache/yarn
       - ~/.gradle/caches
       - ~/.gradle/wrapper
       - ~/.android/build-cache
+      - ./app/node_modules
 
   - &ios-cache
     directories:
@@ -45,6 +47,9 @@ jobs:
       language: android
       jdk: oraclejdk8
       android: *android
+      before_cache:
+        - rm -f ~/.gradle/caches/modules-2/modules-2.lock
+        - rm -fr ~/.gradle/caches/*/plugin-resolution/
       cache: *android-cache
       before_install:
         - rvm install 2.6.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
       cache: *android-cache
       before_install:
         - rvm install 2.6.5
-        - bundle install --deployment
+        - bundle install --deployment --gemfile=./app/Gemfile
         - nvm install 10.17.0
         - npm install -g yarn
         - yes | sdkmanager "platforms;android-28"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
         - yarn install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
       script:
         - yarn lint
-        - yarn test
+        - yarn test --colors
     # - stage: ios-beta
     #   if: branch = master AND type = push
     #   os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
       cache: *android-cache
       before_install:
         - rvm install 2.6.5
-        - bundle install --deployment --gemfile=./app/Gemfile
+        - gem install fastlane
         - nvm install 10.17.0
         - npm install -g yarn
         - yes | sdkmanager "platforms;android-28"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,26 @@ aliases:
       - ~/Library/Caches/Yarn
       - ~/Library/Caches/CocoaPods
 
+  - &test-cache
+    yarn: true
+    directories:
+      - ~/.cache/yarn
+      - ./app/node_modules
+
 jobs:
   include:
+    - stage: lint-and-test
+      if: branch != master
+      language: node_js
+      cache: *test-cache
+      node_js:
+        - "10"
+      install:
+        - git submodule update --init --recursive
+        - cd app && yarn install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
+      script:
+        - cd app && yarn lint
+        - cd app && yarn test
     # - stage: ios-beta
     #   if: branch = master AND type = push
     #   os: osx
@@ -43,27 +61,27 @@ jobs:
     #     - "./install-deps-ios.sh"
     #   script:
     #     - "./deploy-ios-beta.sh"
-    - stage: android-beta
-      # if: branch = master AND type = push
-      language: android
-      jdk: oraclejdk8
-      android: *android
-      before_cache:
-        - rm -f ~/.gradle/caches/modules-2/modules-2.lock
-        - rm -fr ~/.gradle/caches/*/plugin-resolution/
-      cache: *android-cache
-      before_install:
-        - rvm install 2.6.5
-        - gem install fastlane
-        - nvm install 10.17.0
-        - npm install -g yarn
-        - yes | sdkmanager "platforms;android-28"
-        - yes | sdkmanager "build-tools;28.0.3"
-      install:
-        - "./write-android-keys.sh"
-        - "./install-deps-android.sh"
-      script:
-        - "./deploy-android-beta.sh"
+    # - stage: android-beta
+    #   if: branch = master AND type = push
+    #   language: android
+    #   jdk: oraclejdk8
+    #   android: *android
+    #   before_cache:
+    #     - rm -f ~/.gradle/caches/modules-2/modules-2.lock
+    #     - rm -fr ~/.gradle/caches/*/plugin-resolution/
+    #   cache: *android-cache
+    #   before_install:
+    #     - rvm install 2.6.5
+    #     - gem install fastlane
+    #     - nvm install 10.17.0
+    #     - npm install -g yarn
+    #     - yes | sdkmanager "platforms;android-28"
+    #     - yes | sdkmanager "build-tools;28.0.3"
+    #   install:
+    #     - "./write-android-keys.sh"
+    #     - "./install-deps-android.sh"
+    #   script:
+    #     - "./deploy-android-beta.sh"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,12 @@ aliases:
       - ./app/node_modules
 
   - &ios-cache
+    yarn: true
     directories:
       - ~/.rncache
       - ~/Library/Caches/Yarn
       - ~/Library/Caches/CocoaPods
+      - ./app/node_modules
 
   - &test-cache
     yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,43 +48,43 @@ jobs:
       script:
         - yarn lint
         - yarn test --colors
-    # - stage: ios-beta
-    #   if: branch = master AND type = push
-    #   os: osx
-    #   osx_image: xcode11.3
-    #   language: node_js
-    #   cache: *ios-cache
-    #   node_js:
-    #     - lts/*
-    #   before_install:
-    #     - sudo gem install fastlane
-    #     - npm install -g yarn
-    #   install:
-    #     - "./write-ios-keys.sh"
-    #     - "./install-deps-ios.sh"
-    #   script:
-    #     - "./deploy-ios-beta.sh"
-    # - stage: android-beta
-    #   if: branch = master AND type = push
-    #   language: android
-    #   jdk: oraclejdk8
-    #   android: *android
-    #   before_cache:
-    #     - rm -f ~/.gradle/caches/modules-2/modules-2.lock
-    #     - rm -fr ~/.gradle/caches/*/plugin-resolution/
-    #   cache: *android-cache
-    #   before_install:
-    #     - rvm install 2.6.5
-    #     - gem install fastlane
-    #     - nvm install 10.17.0
-    #     - npm install -g yarn
-    #     - yes | sdkmanager "platforms;android-28"
-    #     - yes | sdkmanager "build-tools;28.0.3"
-    #   install:
-    #     - "./write-android-keys.sh"
-    #     - "./install-deps-android.sh"
-    #   script:
-    #     - "./deploy-android-beta.sh"
+    - stage: ios-beta
+      if: branch = master AND type = push
+      os: osx
+      osx_image: xcode11.3
+      language: node_js
+      cache: *ios-cache
+      node_js:
+        - lts/*
+      before_install:
+        - sudo gem install fastlane
+        - npm install -g yarn
+      install:
+        - "./write-ios-keys.sh"
+        - "./install-deps-ios.sh"
+      script:
+        - "./deploy-ios-beta.sh"
+    - stage: android-beta
+      if: branch = master AND type = push
+      language: android
+      jdk: oraclejdk8
+      android: *android
+      before_cache:
+        - rm -f ~/.gradle/caches/modules-2/modules-2.lock
+        - rm -fr ~/.gradle/caches/*/plugin-resolution/
+      cache: *android-cache
+      before_install:
+        - rvm install 2.6.5
+        - gem install fastlane
+        - nvm install 10.17.0
+        - npm install -g yarn
+        - yes | sdkmanager "platforms;android-28"
+        - yes | sdkmanager "build-tools;28.0.3"
+      install:
+        - "./write-android-keys.sh"
+        - "./install-deps-android.sh"
+      script:
+        - "./deploy-android-beta.sh"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,25 +24,24 @@ aliases:
 
 jobs:
   include:
-    - stage: ios-beta
-      if: branch = master AND type = push
-      os: osx
-      osx_image: xcode11.3
-      language: node_js
-      cache: *ios-cache
-      node_js:
-        - lts/*
-      before_install:
-        - sudo gem install fastlane
-        - npm install -g yarn
-      install:
-        - "./write-ios-keys.sh"
-        - "./install-deps-ios.sh"
-      script:
-        - "./deploy-ios-beta.sh"
-
+    # - stage: ios-beta
+    #   if: branch = master AND type = push
+    #   os: osx
+    #   osx_image: xcode11.3
+    #   language: node_js
+    #   cache: *ios-cache
+    #   node_js:
+    #     - lts/*
+    #   before_install:
+    #     - sudo gem install fastlane
+    #     - npm install -g yarn
+    #   install:
+    #     - "./write-ios-keys.sh"
+    #     - "./install-deps-ios.sh"
+    #   script:
+    #     - "./deploy-ios-beta.sh"
     - stage: android-beta
-      if: branch = master AND type = push
+      # if: branch = master AND type = push
       language: android
       jdk: oraclejdk8
       android: *android

--- a/app/android/app/versionCode.gradle
+++ b/app/android/app/versionCode.gradle
@@ -1,7 +1,7 @@
 task('updateVersion') {
     description= "Increments the version code and applies a new version name"
     doLast {
-        def versionCode = Integer.parseInt(VERSION_CODE) + 1
+        def versionCode = version_code
         def versionName = version_number
         ant.propertyfile(file: "../gradle.properties") {
             entry(key: "VERSION_CODE", value: versionCode)

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -86,7 +86,7 @@ platform :android do
         package = load_json(json_path: PACKAGE_JSON_PATH)
 
         gradle(task: 'clean', project_dir: 'android/')
-        gradle(task: 'updateVersion', project_dir: 'android/', properties: { "version_number" => package["version"] })
+        gradle(task: 'updateVersion', project_dir: 'android/', properties: { "version_number" => package["version"], "version_code" => package["versionCode"] })
         gradle(task: 'bundle', build_type: 'Release', project_dir: 'android/')
     end
 

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -2,29 +2,27 @@ fastlane_version '2.140.0'
 
 REPO = "git@github.com:WorldBrain/Memex-Mobile.git"
 REMOTE = "ssh-origin"
+
+TEAM = "5YUPQC9D96"
 MAIN_APP_ID = "io.worldbrain.memex"
 MAIN_APP_PROFILE = "match AppStore io.worldbrain.memex"
 EXT_APP_ID = "io.worldbrain.memex.MemexShare"
 EXT_APP_PROFILE = "match AppStore io.worldbrain.memex.MemexShare"
-ANDROID_APP_ID = "io.worldbrain"
-TEAM = "5YUPQC9D96"
-XCWORKSPACE_PATH = "./ios/app.xcworkspace"
-XCPROJ_PATH = "./ios/app.xcodeproj"
+
 APPLE_USER_ID = "dev@worldbrain.io"
 APPLE_APP_ID = "1471860331"
-PACKAGE_JSON_PATH = "./package.json"
-AAB_PATH = "./android/app/build/outputs/bundle/release/app.aab"
+ANDROID_APP_ID = "io.worldbrain"
+
 ANDROID_SERVICE_JSON_PATH = "./android/service-account.json"
+PACKAGE_JSON_PATH = "./package.json"
+XCWORKSPACE_PATH = "./ios/app.xcworkspace"
+XCPROJ_PATH = "./ios/app.xcodeproj"
+AAB_PATH = "./android/app/build/outputs/bundle/release/app.aab"
+
 
 before_all do
     # ensure_git_status_clean
     git_pull
-end
-
-lane :push_to_git_ssh_remote do
-    branch = git_branch
-    sh("git", "remote", "add", REMOTE, REPO)
-    sh("git", "push", REMOTE, branch)
 end
 
 
@@ -46,7 +44,6 @@ platform :ios do
         package = load_json(json_path: PACKAGE_JSON_PATH)
 
         certificates
-        increment_build_number(xcodeproj: XCPROJ_PATH)
         increment_version_number(xcodeproj: XCPROJ_PATH, version_number: package["version"])
         gym(
             scheme: 'app',
@@ -75,14 +72,12 @@ platform :ios do
             apple_id: APPLE_APP_ID,
             skip_waiting_for_build_processing: true
         )
-        commit_version_bump(message: 'Bump iOS version', xcodeproj: XCPROJ_PATH)
-        push_to_git_ssh_remote
     end
 end
 
 platform :android do
     desc 'Build a new Android application version.'
-    private_lane :build do
+    lane :build do
         package = load_json(json_path: PACKAGE_JSON_PATH)
 
         gradle(task: 'clean', project_dir: 'android/')
@@ -105,7 +100,5 @@ platform :android do
             skip_upload_screenshots: true,
             skip_upload_apk: true
         )
-        git_commit(path: ['./android/gradle.properties'], message: 'Bump Android version')
-        push_to_git_ssh_remote
     end
 end

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,7 @@
 {
     "name": "memex-mobile",
     "version": "1.2.55",
+    "versionCode": "40",
     "private": true,
     "scripts": {
         "start": "react-native start",

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
         "build:deptree": "depcruise --exclude '^node_modules' --output-type dot ./src | dot -T svg > /tmp/dependencygraph.svg",
         "build:android-release": "sh build-android-release.sh",
         "format": "prettier --config prettier.config.js --write '**/*.{ts,js,tsx,jsx,css,md}'",
-        "android:beta": "bundle exec fastlane android beta",
+        "android:beta": "fastlane android beta",
         "ios:beta": "fastlane ios beta",
         "postinstall": "jetify"
     },

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
         "build:deptree": "depcruise --exclude '^node_modules' --output-type dot ./src | dot -T svg > /tmp/dependencygraph.svg",
         "build:android-release": "sh build-android-release.sh",
         "format": "prettier --config prettier.config.js --write '**/*.{ts,js,tsx,jsx,css,md}'",
-        "android:beta": "fastlane android beta",
+        "android:beta": "bundle exec fastlane android beta",
         "ios:beta": "fastlane ios beta",
         "postinstall": "jetify"
     },

--- a/app/src/features/overview/ui/screens/dashboard/logic.ts
+++ b/app/src/features/overview/ui/screens/dashboard/logic.ts
@@ -325,8 +325,8 @@ export default class Logic extends UILogic<State, Event> {
                     })
                     this.emitMutation({
                         pages: state => {
-                            const page = state.get(url)!
-                            return state.set(url, { ...page, isStarred })
+                            const current = state.get(url)!
+                            return state.set(url, { ...current, isStarred })
                         },
                     })
                 } finally {

--- a/app/src/features/page-share/ui/screens/share-modal/logic.ts
+++ b/app/src/features/page-share/ui/screens/share-modal/logic.ts
@@ -1,3 +1,4 @@
+// tslint:disable:no-console
 import { UILogic, UIEvent, IncomingUIEvent, UIMutation } from 'ui-logic-core'
 import { SyncReturnValue } from '@worldbrain/storex-sync'
 

--- a/app/src/features/sync/ui/screens/sync/logic.test.ts
+++ b/app/src/features/sync/ui/screens/sync/logic.test.ts
@@ -66,6 +66,8 @@ describe('SyncScreen', () => {
                 }),
             ]
 
+            expect(1).toBe(2)
+
             expect(
                 userInterfaces.map(ui => ui.logicContainer.state.status),
             ).toEqual(['setup', 'setup'])

--- a/app/src/features/sync/ui/screens/sync/logic.test.ts
+++ b/app/src/features/sync/ui/screens/sync/logic.test.ts
@@ -66,8 +66,6 @@ describe('SyncScreen', () => {
                 }),
             ]
 
-            expect(1).toBe(2)
-
             expect(
                 userInterfaces.map(ui => ui.logicContainer.state.status),
             ).toEqual(['setup', 'setup'])

--- a/app/src/services/setup.ts
+++ b/app/src/services/setup.ts
@@ -1,3 +1,4 @@
+// tslint:disable:no-console
 import { appGroup } from '../../app.json'
 import { ServiceStarter } from './types'
 

--- a/app/src/ui/layouts/sync.tsx
+++ b/app/src/ui/layouts/sync.tsx
@@ -36,7 +36,7 @@ const SyncLayout: React.StatelessComponent<Props> = ({
                 title={props.btnText}
                 onPress={props.onBtnPress!}
                 disabled={props.disableMainBtn}
-                //__notReallyDisabled
+                // __notReallyDisabled
             />
             <Button
                 title={cancelBtnText}

--- a/install-deps-android.sh
+++ b/install-deps-android.sh
@@ -2,6 +2,6 @@
 
 git submodule update --init --recursive
 cd ./app/
-yarn install --frozen-lockfile
+yarn install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
 
 bundle install

--- a/install-deps-ios.sh
+++ b/install-deps-ios.sh
@@ -2,7 +2,7 @@
 
 git submodule update --init --recursive
 cd ./app/
-yarn install --frozen-lockfile
+yarn install --frozen-lockfile --non-interactive --cache-folder ~/Library/Caches/Yarn
 
 cd ./ios/
 pod install

--- a/write-android-keys.sh
+++ b/write-android-keys.sh
@@ -3,9 +3,11 @@
 ENV_FILE="./app/android/app/google-services.json"
 SERVICE_ACC_KEY="./app/android/service-account.json"
 SIGN_KEY="./app/android/app/my-upload-key.keystore"
-declare -r SSH_FILE="$(mktemp -u $HOME/.ssh/id_rsa)"
+SSH_DIR="$HOME/.ssh"
+SSH_FILE="$SSH_DIR/id_rsa"
 
 # Set up private key
+mkdir $SSH_DIR
 echo $IOS_REPO_PRIVATE_KEY | base64 -d > $SSH_FILE
 chmod 600 $SSH_FILE
 

--- a/write-android-keys.sh
+++ b/write-android-keys.sh
@@ -3,11 +3,9 @@
 ENV_FILE="./app/android/app/google-services.json"
 SERVICE_ACC_KEY="./app/android/service-account.json"
 SIGN_KEY="./app/android/app/my-upload-key.keystore"
-SSH_DIR="$HOME/.ssh"
-SSH_FILE="$SSH_DIR/id_rsa"
+SSH_FILE="$HOME/.ssh/id_rsa"
 
 # Set up private key
-mkdir $SSH_DIR
 echo $IOS_REPO_PRIVATE_KEY | base64 -d > $SSH_FILE
 chmod 600 $SSH_FILE
 


### PR DESCRIPTION
## Misc. fixes:

- [x]  ~not being able to push version bump commits~
    - [x]  ~iOS: `git push ssh-origin master` returns "Everything up-to-date"~
        - does a commit really get made?
    - [x]  ~Android: `/home/travis/.ssh/config line 9: Missing argument.` when pushing~
        - same config as iOS VM, though different OSes
        - are they both using the same OpenSSH version? Default options the same?
    - How important is this? we'll still need some way to manually update version numbers. Also need to deal with not re-triggering CD when these commits are pushed. **Perhaps a better approach is simplifying the steps needed to follow to trigger a CD build**
    - **Conclusion:** simplified the trigger build instructions to a single file to update version number + code, removed the need for the pipeline to commit
- [ ]  ~Ensure new Android builds get uploaded to Play Store production track rather than beta track~
  - _comment from notion to @blackforestboi_ : This might depend on how you want to do releases. From what I understand, it currently works like: CD pipeline uploads new builds to the beta track, which are released straight away, and won't go out to production unless you manually log in and press the button. 
Updating this would instead make the CD pipeline upload new builds straight to the production track, and I think release them straight away
- [x]  still run test CI stages on normal branches

## Misc. improvements:

- [x]  ~Update instructions:~

[CD Pipeline instructions](https://www.notion.so/CD-Pipeline-instructions-2050caf8823948f6beb296129224f27a)

- [x]  ~get a way to be able to test the pipeline locally~
    - development is extremely painful having to actually push new commits to our repo and wait for CI's slower VMs to run through things
    - solution detailed here, essentially just trying to find out which setup is being used on our Travis builds and running that container locally, mimicking commands: [https://stackoverflow.com/questions/21053657/how-to-run-travis-ci-locally/49019950#49019950](https://stackoverflow.com/questions/21053657/how-to-run-travis-ci-locally/49019950#49019950)
    - however, we rely on both an Ubuntu and macOS Travis instances to run Android and iOS builds - we can't just spin up a macOS container in docker, so we'd only be able to replicate the Android build env - could just use our own macs
    - it would also require us to write a script to run, mimicking the steps generated from our travis.yml - it won't just read that like the Travis GH service does
    - **Conclusion:** possible to replicate set-up but would require a few days work to all set up nicely. May be better to treat as another task we could schedule for some time in the (hopefully near) future

- [ ]  get build/dep caches working
    - great ideas in [https://medium.com/@tjkangs/travisci-circleci-2-0-with-fastlane-for-react-native-both-ios-and-android-3f99b71b8691](https://medium.com/@tjkangs/travisci-circleci-2-0-with-fastlane-for-react-native-both-ios-and-android-3f99b71b8691)
    - [ ]  iOS:
        - [ ]  pods
        - [ ]  yarn
        - [ ]  build
    - [x]  android
        - [ ]  gem - could not get working; ended up encountering issues, like running out of OS file watchers during build
        - [x]  yarn
        - [x]  build
- [ ]  get separate beta builds working on develop branch (see other task: https://www.notion.so/worldbrain/Add-separate-app-for-develop-branch-with-staging-environment-keys-so-we-can-both-have-a-production-4aebcdf84eae4a31960f61bac39ca0c6)
