### PR TITLE
Add bookmarks and visits filters to dashboard

### DIFF
--- a/app/src/features/meta-picker/ui/screens/meta-picker/logic.ts
+++ b/app/src/features/meta-picker/ui/screens/meta-picker/logic.ts
@@ -24,6 +24,7 @@ export interface Props extends NavigationProps {
     onEntryPress: (item: MetaTypeShape) => Promise<void>
     suggestInputPlaceholder?: string
     singleSelect?: boolean
+    extraEntries?: string[]
     initEntries?: string[]
     initEntry?: string
     className?: string
@@ -72,6 +73,10 @@ export default class Logic extends UILogic<State, Event> {
                       url: this.props.url,
                   })
         const entries = new Map<string, MetaTypeShape>()
+
+        this.props.extraEntries?.forEach(name => {
+            entries.set(name, { name, isChecked: false })
+        })
 
         results.forEach(res => {
             entries.set(res.name, res)

--- a/app/src/features/overview/storage/index.test.data.ts
+++ b/app/src/features/overview/storage/index.test.data.ts
@@ -1,6 +1,6 @@
 import { Page } from '../types'
 
-export const pages: Omit<Page, 'domain' | 'hostname'>[] = [
+export const pages: Omit<Page, 'domain' | 'hostname' | 'pageUrl'>[] = [
     {
         url: 'test.com',
         fullUrl: 'https://www.test.com',

--- a/app/src/features/overview/storage/index.test.ts
+++ b/app/src/features/overview/storage/index.test.ts
@@ -131,4 +131,131 @@ describe('overview StorageModule', () => {
             expect(await overview.findPageVisits(page)).toEqual([])
         }
     })
+
+    it('should be able to find latest bookmarks', async ({
+        storage: {
+            modules: { overview },
+        },
+    }) => {
+        for (const page of data.pages) {
+            await overview.createPage(page)
+        }
+
+        await overview.setPageStar({ url: data.pages[0].url, isStarred: true })
+        await overview.setPageStar({ url: data.pages[2].url, isStarred: true })
+
+        expect(
+            await overview.findLatestBookmarks({ limit: 10, skip: 0 }),
+        ).toEqual([
+            { url: data.pages[2].url, time: expect.any(Number) },
+            { url: data.pages[0].url, time: expect.any(Number) },
+        ])
+
+        await overview.setPageStar({ url: data.pages[1].url, isStarred: true })
+
+        expect(
+            await overview.findLatestBookmarks({ limit: 10, skip: 0 }),
+        ).toEqual([
+            { url: data.pages[1].url, time: expect.any(Number) },
+            { url: data.pages[2].url, time: expect.any(Number) },
+            { url: data.pages[0].url, time: expect.any(Number) },
+        ])
+
+        expect(
+            await overview.findLatestBookmarks({ limit: 10, skip: 1 }),
+        ).toEqual([
+            { url: data.pages[2].url, time: expect.any(Number) },
+            { url: data.pages[0].url, time: expect.any(Number) },
+        ])
+
+        expect(
+            await overview.findLatestBookmarks({ limit: 10, skip: 2 }),
+        ).toEqual([{ url: data.pages[0].url, time: expect.any(Number) }])
+
+        expect(
+            await overview.findLatestBookmarks({ limit: 1, skip: 0 }),
+        ).toEqual([{ url: data.pages[1].url, time: expect.any(Number) }])
+
+        expect(
+            await overview.findLatestBookmarks({ limit: 1, skip: 1 }),
+        ).toEqual([{ url: data.pages[2].url, time: expect.any(Number) }])
+
+        expect(
+            await overview.findLatestBookmarks({ limit: 1, skip: 2 }),
+        ).toEqual([{ url: data.pages[0].url, time: expect.any(Number) }])
+
+        expect(
+            await overview.findLatestBookmarks({ limit: 1, skip: 3 }),
+        ).toEqual([])
+    })
+
+    it('should be able to find latest visits for each page', async ({
+        storage: {
+            modules: { overview },
+        },
+    }) => {
+        for (const page of data.pages) {
+            await overview.createPage(page)
+        }
+
+        const times = [
+            Date.now() - 1000,
+            Date.now() - 900,
+            Date.now() - 800,
+            Date.now() - 700,
+            Date.now() - 600,
+        ]
+
+        await overview.visitPage({ url: data.pages[0].url, time: times[0] })
+        await overview.visitPage({ url: data.pages[0].url, time: times[2] })
+        await overview.visitPage({ url: data.pages[2].url, time: times[1] })
+
+        expect(
+            await overview.findLatestVisitsByPage({ limit: 10, skip: 0 }),
+        ).toEqual([
+            { url: data.pages[0].url, time: times[2] },
+            { url: data.pages[2].url, time: times[1] },
+        ])
+
+        await overview.visitPage({ url: data.pages[1].url, time: times[3] })
+        await overview.visitPage({ url: data.pages[1].url, time: times[0] })
+        await overview.visitPage({ url: data.pages[1].url, time: times[1] })
+
+        expect(
+            await overview.findLatestVisitsByPage({ limit: 10, skip: 0 }),
+        ).toEqual([
+            { url: data.pages[1].url, time: times[3] },
+            { url: data.pages[0].url, time: times[2] },
+            { url: data.pages[2].url, time: times[1] },
+        ])
+
+        expect(
+            await overview.findLatestVisitsByPage({ limit: 10, skip: 1 }),
+        ).toEqual([
+            { url: data.pages[0].url, time: times[2] },
+            { url: data.pages[2].url, time: times[1] },
+        ])
+
+        expect(
+            await overview.findLatestVisitsByPage({ limit: 10, skip: 2 }),
+        ).toEqual([{ url: data.pages[2].url, time: times[1] }])
+
+        expect(
+            await overview.findLatestVisitsByPage({ limit: 10, skip: 3 }),
+        ).toEqual([])
+
+        expect(
+            await overview.findLatestVisitsByPage({ limit: 2, skip: 0 }),
+        ).toEqual([
+            { url: data.pages[1].url, time: times[3] },
+            { url: data.pages[0].url, time: times[2] },
+        ])
+
+        expect(
+            await overview.findLatestVisitsByPage({ limit: 2, skip: 1 }),
+        ).toEqual([
+            { url: data.pages[0].url, time: times[2] },
+            { url: data.pages[2].url, time: times[1] },
+        ])
+    })
 })

--- a/app/src/features/overview/types.ts
+++ b/app/src/features/overview/types.ts
@@ -5,6 +5,8 @@ export type NativeTouchEventHandler = (
 ) => void
 export type ResultType = 'special' | 'pages' | 'notes'
 
+export type DashboardFilterType = 'collection' | 'bookmarks' | 'visits'
+
 export interface UICollection {
     id: number
     name: string

--- a/app/src/features/overview/ui/screens/dashboard/logic.test.ts
+++ b/app/src/features/overview/ui/screens/dashboard/logic.test.ts
@@ -48,7 +48,7 @@ describe('dashboard screen UI logic tests', () => {
         })
         const element = new FakeStatefulUIElement<State, Event>(logic)
 
-        return { element }
+        return { element, logic }
     }
 
     async function createRecentlyVisitedPage(
@@ -74,18 +74,20 @@ describe('dashboard screen UI logic tests', () => {
         const { element } = setup(dependencies)
 
         await element.init()
-        expect(element.state).toEqual({
-            syncState: expect.any(String),
-            shouldShowSyncRibbon: false,
-            loadState: 'done',
-            reloadState: 'pristine',
-            loadMoreState: 'pristine',
-            selectedListName: MOBILE_LIST_NAME,
-            couldHaveMore: false,
-            actionState: 'pristine',
-            actionFinishedAt: 0,
-            pages: new Map(),
-        })
+        expect(element.state).toEqual(
+            expect.objectContaining({
+                syncState: expect.any(String),
+                shouldShowSyncRibbon: false,
+                loadState: 'done',
+                reloadState: 'pristine',
+                loadMoreState: 'pristine',
+                selectedListName: MOBILE_LIST_NAME,
+                couldHaveMore: false,
+                actionState: 'pristine',
+                actionFinishedAt: 0,
+                pages: new Map(),
+            }),
+        )
     })
 
     it('should load correctly with saved pages', async dependencies => {
@@ -95,28 +97,30 @@ describe('dashboard screen UI logic tests', () => {
         await addToMobileList(INTEGRATION_TEST_DATA.pages[0].url, dependencies)
 
         await element.init()
-        expect(element.state).toEqual({
-            syncState: expect.any(String),
-            shouldShowSyncRibbon: false,
-            loadState: 'done',
-            reloadState: 'pristine',
-            loadMoreState: 'pristine',
-            couldHaveMore: false,
-            actionState: 'pristine',
-            actionFinishedAt: 0,
-            selectedListName: MOBILE_LIST_NAME,
-            pages: new Map([
-                [
-                    'test.com',
-                    {
-                        ...UI_PAGE_1,
-                        isStarred: true,
-                        tags: INTEGRATION_TEST_DATA.tags,
-                        lists: [INTEGRATION_TEST_DATA.lists[0]],
-                    },
-                ],
-            ]),
-        })
+        expect(element.state).toEqual(
+            expect.objectContaining({
+                syncState: expect.any(String),
+                shouldShowSyncRibbon: false,
+                loadState: 'done',
+                reloadState: 'pristine',
+                loadMoreState: 'pristine',
+                couldHaveMore: false,
+                actionState: 'pristine',
+                actionFinishedAt: 0,
+                selectedListName: MOBILE_LIST_NAME,
+                pages: new Map([
+                    [
+                        'test.com',
+                        {
+                            ...UI_PAGE_1,
+                            isStarred: true,
+                            tags: INTEGRATION_TEST_DATA.tags,
+                            lists: [INTEGRATION_TEST_DATA.lists[0]],
+                        },
+                    ],
+                ]),
+            }),
+        )
     })
 
     it('should paginate correctly', async dependencies => {
@@ -145,66 +149,74 @@ describe('dashboard screen UI logic tests', () => {
         })
 
         await element.init()
-        expect(element.state).toEqual({
-            syncState: expect.any(String),
-            shouldShowSyncRibbon: false,
-            loadState: 'done',
-            reloadState: 'pristine',
-            loadMoreState: 'pristine',
-            couldHaveMore: true,
-            actionState: 'pristine',
-            actionFinishedAt: 0,
-            pages: new Map([['test.com.me', UI_PAGE_2]]),
-            selectedListName: MOBILE_LIST_NAME,
-        })
+        expect(element.state).toEqual(
+            expect.objectContaining({
+                syncState: expect.any(String),
+                shouldShowSyncRibbon: false,
+                loadState: 'done',
+                reloadState: 'pristine',
+                loadMoreState: 'pristine',
+                couldHaveMore: true,
+                actionState: 'pristine',
+                actionFinishedAt: 0,
+                pages: new Map([['test.com.me', UI_PAGE_2]]),
+                selectedListName: MOBILE_LIST_NAME,
+            }),
+        )
 
         await element.processEvent('loadMore', {})
-        expect(element.state).toEqual({
-            syncState: expect.any(String),
-            shouldShowSyncRibbon: false,
-            loadState: 'done',
-            reloadState: 'pristine',
-            loadMoreState: 'done',
-            couldHaveMore: true,
-            actionState: 'pristine',
-            actionFinishedAt: 0,
-            selectedListName: MOBILE_LIST_NAME,
-            pages: new Map([
-                ['test.com.me', UI_PAGE_2],
-                ['test.com', UI_PAGE_1],
-            ]),
-        })
+        expect(element.state).toEqual(
+            expect.objectContaining({
+                syncState: expect.any(String),
+                shouldShowSyncRibbon: false,
+                loadState: 'done',
+                reloadState: 'pristine',
+                loadMoreState: 'done',
+                couldHaveMore: true,
+                actionState: 'pristine',
+                actionFinishedAt: 0,
+                selectedListName: MOBILE_LIST_NAME,
+                pages: new Map([
+                    ['test.com.me', UI_PAGE_2],
+                    ['test.com', UI_PAGE_1],
+                ]),
+            }),
+        )
 
         await element.processEvent('loadMore', {})
-        expect(element.state).toEqual({
-            syncState: expect.any(String),
-            shouldShowSyncRibbon: false,
-            loadState: 'done',
-            reloadState: 'pristine',
-            loadMoreState: 'done',
-            couldHaveMore: false,
-            actionState: 'pristine',
-            actionFinishedAt: 0,
-            selectedListName: MOBILE_LIST_NAME,
-            pages: new Map([
-                ['test.com.me', UI_PAGE_2],
-                ['test.com', UI_PAGE_1],
-            ]),
-        })
+        expect(element.state).toEqual(
+            expect.objectContaining({
+                syncState: expect.any(String),
+                shouldShowSyncRibbon: false,
+                loadState: 'done',
+                reloadState: 'pristine',
+                loadMoreState: 'done',
+                couldHaveMore: false,
+                actionState: 'pristine',
+                actionFinishedAt: 0,
+                selectedListName: MOBILE_LIST_NAME,
+                pages: new Map([
+                    ['test.com.me', UI_PAGE_2],
+                    ['test.com', UI_PAGE_1],
+                ]),
+            }),
+        )
 
         await element.processEvent('reload', {})
-        expect(element.state).toEqual({
-            syncState: expect.any(String),
-            shouldShowSyncRibbon: false,
-            loadState: 'done',
-            reloadState: 'done',
-            loadMoreState: 'done',
-            couldHaveMore: true,
-            actionState: 'pristine',
-            actionFinishedAt: 0,
-            selectedListName: MOBILE_LIST_NAME,
-            pages: new Map([['test.com.me', UI_PAGE_2]]),
-        })
+        expect(element.state).toEqual(
+            expect.objectContaining({
+                syncState: expect.any(String),
+                shouldShowSyncRibbon: false,
+                loadState: 'done',
+                reloadState: 'done',
+                loadMoreState: 'done',
+                couldHaveMore: true,
+                actionState: 'pristine',
+                actionFinishedAt: 0,
+                selectedListName: MOBILE_LIST_NAME,
+                pages: new Map([['test.com.me', UI_PAGE_2]]),
+            }),
+        )
     })
 
     it('should be able to delete pages', async dependencies => {
@@ -222,19 +234,21 @@ describe('dashboard screen UI logic tests', () => {
         await element.processEvent('deletePage', {
             url,
         })
-        expect(element.state).toEqual({
-            syncState: expect.any(String),
-            shouldShowSyncRibbon: false,
-            loadState: 'done',
-            reloadState: 'pristine',
-            loadMoreState: 'pristine',
-            couldHaveMore: false,
-            action: 'delete',
-            actionState: 'done',
-            actionFinishedAt: expect.any(Number),
-            selectedListName: MOBILE_LIST_NAME,
-            pages: new Map([]),
-        })
+        expect(element.state).toEqual(
+            expect.objectContaining({
+                syncState: expect.any(String),
+                shouldShowSyncRibbon: false,
+                loadState: 'done',
+                reloadState: 'pristine',
+                loadMoreState: 'pristine',
+                couldHaveMore: false,
+                action: 'delete',
+                actionState: 'done',
+                actionFinishedAt: expect.any(Number),
+                selectedListName: MOBILE_LIST_NAME,
+                pages: new Map([]),
+            }),
+        )
         expect(element.state.actionFinishedAt).toBeGreaterThan(
             Date.now() - 5000,
         )
@@ -278,7 +292,6 @@ describe('dashboard screen UI logic tests', () => {
     })
 
     it('reload should be able to trigger sync ', async dependencies => {
-        const { services } = dependencies
         const { element } = setup(dependencies)
 
         expect(element.state.syncState).toEqual('pristine')
@@ -286,5 +299,50 @@ describe('dashboard screen UI logic tests', () => {
         expect(element.state.syncState).toEqual('pristine')
         await element.processEvent('reload', { triggerSync: true })
         expect(element.state.syncState).not.toEqual('pristine')
+    })
+
+    it('should be able to switch look up of latest collection entries, bookmarks, or visits, depending on set filter', async dependencies => {
+        const {
+            storage: {
+                modules: { overview },
+            },
+        } = dependencies
+        const { element } = setup(dependencies)
+
+        for (const page of INTEGRATION_TEST_DATA.pages) {
+            await overview.createPage(page)
+        }
+
+        await addToMobileList(INTEGRATION_TEST_DATA.pages[0].url, dependencies)
+        await addToMobileList(INTEGRATION_TEST_DATA.pages[3].url, dependencies)
+
+        await overview.starPage({ url: INTEGRATION_TEST_DATA.pages[1].url })
+        await overview.visitPage({ url: INTEGRATION_TEST_DATA.pages[1].url })
+        await overview.visitPage({ url: INTEGRATION_TEST_DATA.pages[4].url })
+
+        const logic = element.logic as Logic
+
+        element.processMutation({ filterType: { $set: 'bookmarks' } })
+        expect(
+            await logic['choosePageEntryLoader'](element.state)(element.state),
+        ).toEqual([
+            { url: INTEGRATION_TEST_DATA.pages[1].url, date: expect.any(Date) },
+        ])
+
+        element.processMutation({ filterType: { $set: 'visits' } })
+        expect(
+            await logic['choosePageEntryLoader'](element.state)(element.state),
+        ).toEqual([
+            { url: INTEGRATION_TEST_DATA.pages[4].url, date: expect.any(Date) },
+            { url: INTEGRATION_TEST_DATA.pages[1].url, date: expect.any(Date) },
+        ])
+
+        element.processMutation({ filterType: { $set: 'collection' } })
+        expect(
+            await logic['choosePageEntryLoader'](element.state)(element.state),
+        ).toEqual([
+            { url: INTEGRATION_TEST_DATA.pages[3].url, date: expect.any(Date) },
+            { url: INTEGRATION_TEST_DATA.pages[0].url, date: expect.any(Date) },
+        ])
     })
 })

--- a/app/src/features/overview/ui/screens/dashboard/logic.ts
+++ b/app/src/features/overview/ui/screens/dashboard/logic.ts
@@ -26,6 +26,7 @@ export interface State {
     action?: 'delete' | 'togglePageStar'
     actionState: UITaskState
     actionFinishedAt: number
+    filterType: 'collection' | 'bookmarks' | 'visits'
 }
 
 export type Event = UIEvent<{
@@ -66,9 +67,11 @@ export default class Logic extends UILogic<State, Event> {
     }
 
     getInitialState(initList?: string): State {
+        const { navigation } = this.props
         const selectedListName =
-            initList ??
-            this.props.navigation.getParam('selectedList', MOBILE_LIST_NAME)
+            initList ?? navigation.getParam('selectedList', MOBILE_LIST_NAME)
+
+        const filterType = navigation.getParam('filterType', 'collection')
 
         return {
             syncState: 'pristine',
@@ -81,6 +84,7 @@ export default class Logic extends UILogic<State, Event> {
             actionFinishedAt: 0,
             pages: new Map(),
             selectedListName,
+            filterType,
         }
     }
 
@@ -213,7 +217,10 @@ export default class Logic extends UILogic<State, Event> {
         let entryLoader: PageLookupEntryLoader
 
         // TODO: stateful switching logic for entry loader
-        entryLoader = this.loadEntriesForCollection
+        entryLoader =
+            prevState.filterType == null
+                ? this.loadEntriesForCollection
+                : this.loadEntriesForBookmarks
 
         try {
             entries = await entryLoader(prevState)

--- a/app/src/features/overview/ui/screens/dashboard/logic.ts
+++ b/app/src/features/overview/ui/screens/dashboard/logic.ts
@@ -132,7 +132,9 @@ export default class Logic extends UILogic<State, Event> {
     }
 
     cleanup() {
-        this.removeAppChangeListener()
+        if (this.removeAppChangeListener) {
+            this.removeAppChangeListener()
+        }
     }
 
     private async doSync() {

--- a/app/src/features/overview/ui/screens/lists-filter/index.tsx
+++ b/app/src/features/overview/ui/screens/lists-filter/index.tsx
@@ -11,6 +11,9 @@ import { MOBILE_LIST_NAME } from '@worldbrain/memex-storage/lib/mobile-app/featu
 import styles from './styles'
 
 export default class ListsFilter extends NavigationScreen<Props, State, Event> {
+    static MAGIC_VISITS_FILTER = 'All History'
+    static MAGIC_BMS_FILTER = 'All Bookmarks'
+
     private selectedEntryName?: string
 
     constructor(props: Props) {
@@ -19,9 +22,22 @@ export default class ListsFilter extends NavigationScreen<Props, State, Event> {
         this.selectedEntryName = this.props.navigation.getParam('selectedList')
     }
 
+    private get magicFilters(): string[] {
+        return [ListsFilter.MAGIC_VISITS_FILTER, ListsFilter.MAGIC_BMS_FILTER]
+    }
+
     private handleEntryPress = async (item: MetaTypeShape) => {
+        let filterType: string | undefined
+
+        if (item.name === ListsFilter.MAGIC_BMS_FILTER) {
+            filterType = 'bookmarks'
+        } else if (item.name === ListsFilter.MAGIC_VISITS_FILTER) {
+            filterType = 'visits'
+        }
+
         this.props.navigation.navigate('Overview', {
             selectedList: item.isChecked ? MOBILE_LIST_NAME : item.name,
+            filterType: !item.isChecked ? filterType : undefined,
         })
     }
 
@@ -49,6 +65,7 @@ export default class ListsFilter extends NavigationScreen<Props, State, Event> {
                 />
                 <MetaPicker
                     {...this.props}
+                    extraEntries={this.magicFilters}
                     onEntryPress={this.handleEntryPress}
                     suggestInputPlaceholder="Search Collections"
                     className={styles.filterContainer}

--- a/app/src/features/overview/ui/screens/lists-filter/index.tsx
+++ b/app/src/features/overview/ui/screens/lists-filter/index.tsx
@@ -7,6 +7,7 @@ import Navigation from '../../components/navigation'
 import MetaPicker from 'src/features/meta-picker/ui/screens/meta-picker'
 import { MetaTypeShape } from 'src/features/meta-picker/types'
 import navigationStyles from 'src/features/overview/ui/components/navigation.styles'
+import { DashboardFilterType } from 'src/features/overview/types'
 import { MOBILE_LIST_NAME } from '@worldbrain/memex-storage/lib/mobile-app/features/meta-picker/constants'
 import styles from './styles'
 
@@ -27,12 +28,14 @@ export default class ListsFilter extends NavigationScreen<Props, State, Event> {
     }
 
     private handleEntryPress = async (item: MetaTypeShape) => {
-        let filterType: string | undefined
+        let filterType: DashboardFilterType
 
         if (item.name === ListsFilter.MAGIC_BMS_FILTER) {
             filterType = 'bookmarks'
         } else if (item.name === ListsFilter.MAGIC_VISITS_FILTER) {
             filterType = 'visits'
+        } else {
+            filterType = 'collection'
         }
 
         this.props.navigation.navigate('Overview', {

--- a/app/src/tests/shared-fixtures/integration.ts
+++ b/app/src/tests/shared-fixtures/integration.ts
@@ -3,7 +3,7 @@ import { Storage } from 'src/storage/types'
 import { getStorageContents } from '@worldbrain/memex-common/lib/storage/utils'
 
 export const INTEGRATION_TEST_DATA: {
-    pages: Omit<Page, 'domain' | 'hostname'>[]
+    pages: Omit<Page, 'domain' | 'hostname' | 'pageUrl'>[]
     visitTimestamps: number[]
     tags: string[]
     lists: string[]
@@ -13,6 +13,34 @@ export const INTEGRATION_TEST_DATA: {
             url: 'test.com',
             fullUrl: 'https://www.test.com',
             fullTitle: 'This is a test page',
+            text:
+                'Hey there this is some test text with lots of test terms included.',
+        },
+        {
+            url: 'test.com/1',
+            fullUrl: 'https://www.test.com/1',
+            fullTitle: 'This is another test page',
+            text:
+                'Hey there this is some test text with lots of test terms included.',
+        },
+        {
+            url: 'test.com/2',
+            fullUrl: 'https://www.test.com/2',
+            fullTitle: 'This is test page 2',
+            text:
+                'Hey there this is some test text with lots of test terms included.',
+        },
+        {
+            url: 'test.com/3',
+            fullUrl: 'https://www.test.com/3',
+            fullTitle: 'This is a test page 3',
+            text:
+                'Hey there this is some test text with lots of test terms included.',
+        },
+        {
+            url: 'test.com/4',
+            fullUrl: 'https://www.test.com/4',
+            fullTitle: 'This is a test page 4',
             text:
                 'Hey there this is some test text with lots of test terms included.',
         },


### PR DESCRIPTION
Allows filtering of pages in the main dashboard by bookmark and visit times: 
https://www.notion.so/worldbrain/Add-2-more-standard-lists-to-the-mobile-app-filter-All-history-Bookmarks-62fa355a0e4141b6863146829bde0d02

## TODOs:
- [x] storage 
  - [x] write bookmarks query
    - [x] write unit tests
  - [x] write visits query*
    - [x] write unit tests
- [x] UI
  - [x] decouple existing collections-specific lookup logic*
  - [x] write bookmarks-specific lookup logic
  - [x] write visits-specific lookup logic
  - [x] write state switching logic to choose which lookup to perform
  - [x] write magic entries in collections filter*
    - [x] refactor meta picker to accept init entries passed down from parent
    - [x] ensure it all makes sense (involves some stuff the components were not originally designed for)
  - [x] ensure all tested*

*presumed to be more time consuming