### PR TITLE
Hotfix/1.5.3 - remove sync device info on unpair

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
     "name": "memex-mobile",
-    "version": "1.5.2",
-    "versionCode": "56",
+    "version": "1.5.3",
+    "versionCode": "57",
     "versionCodeDev": "55",
     "private": true,
     "scripts": {

--- a/app/src/features/overview/ui/screens/pairing-screen/index.tsx
+++ b/app/src/features/overview/ui/screens/pairing-screen/index.tsx
@@ -3,16 +3,25 @@ import { Alert } from 'react-native'
 
 import SyncSuccess from 'src/features/sync/ui/components/sync-success-stage'
 import { storageKeys } from '../../../../../../app.json'
-import { NavigationScreen, NavigationProps, UIServices } from 'src/ui/types'
+import {
+    NavigationScreen,
+    NavigationProps,
+    UIServices,
+    UIStorageModules,
+} from 'src/ui/types'
 
 interface Props extends NavigationProps {
     services: UIServices<'localStorage'>
+    storage: UIStorageModules<'syncInfo'>
 }
 
 export default class RePairScreen extends NavigationScreen<Props, {}, Event> {
     private handleRePairConfirmation = async () => {
-        await this.props.services.localStorage.clear(storageKeys.syncKey)
-        this.props.navigation.navigate('Sync')
+        const { services, storage, navigation } = this.props
+
+        await services.localStorage.clear(storageKeys.syncKey)
+        await storage.modules.syncInfo.removeAllDevices()
+        navigation.navigate('Sync')
     }
 
     private handleRePairChoice = () => {


### PR DESCRIPTION
@blackforestboi wrote in #32 :

> Can we ensure that when people "unpair" a device that it deletes all the devices from the syncdevice list? I think that would solve a lot of issues. (e.g. syncing back deviceIDs from previous syncs into Memex)

Looking at the code, we never set it up to remove any devices from the sync device info collection on unpairing in Memex Go. I have now added code to do that.

@ShishKabab do you know if this is something that should have been implemented all this time? If so, what issues could it lead to say if someone paired with an ext, then unpaired, pairing with another ext or even the same one?